### PR TITLE
feat/add-scripts-to-fetch-2025-pl-season

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.env
+.env.*
+!.env.example
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+Setup
+
+1. Copy .env.example to .env and fill secrets:
+
+   cp .env.example .env
+
+2. Run local tasks as usual; config loads .env automatically in development.
+
+

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Database    *DatabaseConfig
 	Environment string
 	ServerPort  int
+	API         *APIConfig
 }
 
 type DatabaseConfig struct {
@@ -19,6 +20,11 @@ type DatabaseConfig struct {
 	User     string
 	Password string
 	SSLMode  bool
+}
+
+type APIConfig struct {
+	FootballAPIKey string
+	FootballAPIURL string
 }
 
 func GetConfig() *Config {
@@ -32,6 +38,10 @@ func GetConfig() *Config {
 			SSLMode:  getEnvOrDefault("DATABASE_SSL_MODE", false),
 		},
 		ServerPort: getEnvOrDefault("SERVER_PORT", 8080),
+		API: &APIConfig{
+			FootballAPIKey: getEnvOrDefault("FOOTBALL_API_KEY", ""),
+			FootballAPIURL: getEnvOrDefault("FOOTBALL_API_URL", "https://v3.football.api-sports.io"),
+		},
 	}
 	switch strings.ToLower(os.Getenv("ENV")) {
 	case "development":

--- a/config/development.go
+++ b/config/development.go
@@ -2,4 +2,5 @@ package config
 
 func loadDevelopmentConfig(cfg *Config) {
 	cfg.Environment = "development"
+	_ = loadDotenv()
 }

--- a/config/dotenv.go
+++ b/config/dotenv.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"log"
+
+	"github.com/joho/godotenv"
+)
+
+// loadDotenv loads environment variables from a local .env file if present.
+// It is safe to call multiple times; errors are non-fatal in development.
+func loadDotenv() error {
+	if err := godotenv.Load(); err != nil {
+		// Do not fail if .env is missing; just log in development
+		log.Printf(".env not loaded: %v", err)
+		return err
+	}
+	return nil
+}

--- a/db/migrations/20250915071851_20250915042000_alter_teams_unique_name_sport_id.down.sql
+++ b/db/migrations/20250915071851_20250915042000_alter_teams_unique_name_sport_id.down.sql
@@ -1,0 +1,8 @@
+-- Remove composite unique and restore unique on name
+ALTER TABLE teams
+    DROP CONSTRAINT IF EXISTS teams_name_sport_id_key;
+
+-- Recreate unique on name (matches original schema)
+ALTER TABLE teams
+    ADD CONSTRAINT teams_name_key UNIQUE (name);
+

--- a/db/migrations/20250915071851_20250915042000_alter_teams_unique_name_sport_id.up.sql
+++ b/db/migrations/20250915071851_20250915042000_alter_teams_unique_name_sport_id.up.sql
@@ -1,0 +1,18 @@
+-- Drop existing unique constraint on name if it exists
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM   pg_constraint c
+        JOIN   pg_class t ON t.oid = c.conrelid
+        WHERE  t.relname = 'teams'
+        AND    c.conname = 'teams_name_key'
+    ) THEN
+        ALTER TABLE teams DROP CONSTRAINT teams_name_key;
+    END IF;
+END $$;
+
+-- Add composite unique constraint on (name, sport_id)
+ALTER TABLE teams
+    ADD CONSTRAINT teams_name_sport_id_key UNIQUE (name, sport_id);
+

--- a/db/migrations/20250915073004_add_api_id_column_to_teams.down.sql
+++ b/db/migrations/20250915073004_add_api_id_column_to_teams.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_teams_api_id;
+ALTER TABLE teams DROP COLUMN api_id;

--- a/db/migrations/20250915073004_add_api_id_column_to_teams.up.sql
+++ b/db/migrations/20250915073004_add_api_id_column_to_teams.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE teams ADD COLUMN api_id INT;
+
+CREATE INDEX idx_teams_api_id ON teams (api_id);

--- a/db/migrations/20250915075052_20250915043000_add_unique_fixtures_sport_teams_datetime.down.sql
+++ b/db/migrations/20250915075052_20250915043000_add_unique_fixtures_sport_teams_datetime.down.sql
@@ -1,0 +1,4 @@
+-- Drop composite unique constraint
+ALTER TABLE fixtures
+    DROP CONSTRAINT IF EXISTS fixtures_sport_teams_datetime_key;
+

--- a/db/migrations/20250915075052_20250915043000_add_unique_fixtures_sport_teams_datetime.up.sql
+++ b/db/migrations/20250915075052_20250915043000_add_unique_fixtures_sport_teams_datetime.up.sql
@@ -1,0 +1,5 @@
+-- Add composite unique constraint to prevent duplicate fixtures
+ALTER TABLE fixtures
+    ADD CONSTRAINT fixtures_sport_teams_datetime_key
+    UNIQUE (sport_id, team_id_1, team_id_2, date_time);
+

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module mike
 go 1.23.4
 
 require (
+	github.com/joho/godotenv v1.5.1
 	github.com/uptrace/bun v1.2.15
 	github.com/uptrace/bun/dialect/pgdialect v1.2.15
 	github.com/uptrace/bun/driver/pgdriver v1.2.15

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/labstack/echo/v4 v4.13.4 h1:oTZZW+T3s9gAu5L8vmzihV7/lkXGZuITzTQkTEhcXEA=
 github.com/labstack/echo/v4 v4.13.4/go.mod h1:g63b33BZ5vZzcIUF8AtRH40DrTlXnx4UMC8rBdndmjQ=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=

--- a/pkg/routes/fixtures/models/db.go
+++ b/pkg/routes/fixtures/models/db.go
@@ -1,0 +1,20 @@
+package models
+
+import "time"
+
+type Fixture struct {
+	ID       int       `bun:"id,pk,autoincrement" json:"id"`
+	SportID  int       `bun:"sport_id" json:"sport_id"`
+	TeamID1  int       `bun:"team_id_1" json:"team_id_1"`
+	TeamID2  int       `bun:"team_id_2" json:"team_id_2"`
+	DateTime time.Time `bun:"date_time" json:"date_time"`
+	Details  Details   `bun:"details" json:"details"`
+	Status   string    `bun:"status" json:"status"`
+}
+
+type Details struct {
+	HomeTeam string    `json:"home_team"`
+	AwayTeam string    `json:"away_team"`
+	DateTime time.Time `json:"date_time"`
+	Status   string    `json:"status"`
+}

--- a/pkg/routes/fixtures/soccer/models/db.go
+++ b/pkg/routes/fixtures/soccer/models/db.go
@@ -1,0 +1,113 @@
+package models
+
+import (
+	"context"
+	"log"
+	fixtureModels "mike/pkg/routes/fixtures/models"
+	"mike/pkg/routes/teams/models"
+	"mike/utils"
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+// Raw API response structures for fixtures belonging to a league and season for soccer
+type FixturesResponse struct {
+	Get        string            `json:"get"`
+	Parameters map[string]string `json:"parameters"`
+	Errors     []interface{}     `json:"errors"`
+	Results    int               `json:"results"`
+	Paging     struct {
+		Current int `json:"current"`
+		Total   int `json:"total"`
+	} `json:"paging"`
+	Response []FixtureItem `json:"response"`
+}
+
+type FixtureItem struct {
+	Fixture struct {
+		ID        int    `json:"id"`
+		Timezone  string `json:"timezone"`
+		Date      string `json:"date"` // ISO8601
+		Timestamp int64  `json:"timestamp"`
+		Status    struct {
+			Long    string      `json:"long"`
+			Short   string      `json:"short"`
+			Elapsed *int        `json:"elapsed"`
+			Extra   interface{} `json:"extra"`
+		} `json:"status"`
+	} `json:"fixture"`
+	League struct {
+		ID     int    `json:"id"`
+		Name   string `json:"name"`
+		Season int    `json:"season"`
+	} `json:"league"`
+	Teams struct {
+		Home struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		} `json:"home"`
+		Away struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		} `json:"away"`
+	} `json:"teams"`
+}
+
+func getTeamDetails(teamApiId int) (models.Team, error) {
+	db := utils.GetDatabase()
+
+	var team models.Team
+	err := db.NewSelect().Model(&team).Where("api_id = ?", teamApiId).Scan(context.Background())
+	if err != nil {
+		return models.Team{}, err
+	}
+	return team, nil
+}
+
+func (fixture FixtureItem) ToFixture() fixtureModels.Fixture {
+	teamId1, err := getTeamDetails(fixture.Teams.Home.ID)
+	if err != nil {
+		log.Fatalf("Error getting team details: %v", err)
+	}
+	teamId2, err := getTeamDetails(fixture.Teams.Away.ID)
+	if err != nil {
+		log.Fatalf("Error getting team details: %v", err)
+	}
+	date, err := time.Parse(time.RFC3339, fixture.Fixture.Date)
+	if err != nil {
+		log.Fatalf("Error parsing date: %v", err)
+	}
+	return fixtureModels.Fixture{
+		SportID:  5, // Soccer
+		TeamID1:  int(teamId1.ID),
+		TeamID2:  int(teamId2.ID),
+		DateTime: date,
+		Status:   fixture.Fixture.Status.Short,
+		Details: fixtureModels.Details{
+			HomeTeam: teamId1.Name,
+			AwayTeam: teamId2.Name,
+			DateTime: date,
+			Status:   fixture.Fixture.Status.Short,
+		},
+	}
+}
+
+func (fixturesResp FixturesResponse) ToFixtures() []fixtureModels.Fixture {
+	fixtures := make([]fixtureModels.Fixture, 0, len(fixturesResp.Response))
+	for _, fixture := range fixturesResp.Response {
+		fixtures = append(fixtures, fixture.ToFixture())
+	}
+	return fixtures
+}
+
+func InsertFixtures(db *bun.DB, fixtures []fixtureModels.Fixture) error {
+	if len(fixtures) == 0 {
+		return nil
+	}
+	_, err := db.NewInsert().
+		Model(&fixtures).
+		On("CONFLICT (sport_id, team_id_1, team_id_2, date_time) DO NOTHING").
+		Exec(context.Background())
+	return err
+}

--- a/pkg/routes/teams/models/db.go
+++ b/pkg/routes/teams/models/db.go
@@ -1,0 +1,15 @@
+// Generic teams model for all sports
+package models
+
+import "github.com/uptrace/bun"
+
+type Team struct {
+	bun.BaseModel `bun:"teams"`
+	ID            int64  `bun:"id,pk,autoincrement" json:"id"`
+	Name          string `bun:"name" json:"name"`
+	SportId       int    `bun:"sport_id" json:"sport_id"`
+	Description   string `bun:"description" json:"description"`
+	ImageURL      string `bun:"image_url" json:"image_url"`
+	IsActive      bool   `bun:"is_active" json:"is_active"`
+	ApiID         int    `bun:"api_id" json:"api_id"`
+}

--- a/pkg/routes/teams/soccer/models/db.go
+++ b/pkg/routes/teams/soccer/models/db.go
@@ -1,0 +1,78 @@
+package models
+
+import (
+	"context"
+	"mike/pkg/routes/teams/models"
+
+	"github.com/uptrace/bun"
+)
+
+const SoccerSportId = 5
+
+// API Response structures for teams belonging to a league and season for soccer
+type TeamsResponse struct {
+	Get        string `json:"get"`
+	Parameters struct {
+		League string `json:"league"`
+		Season string `json:"season"`
+	} `json:"parameters"`
+	Errors  []interface{} `json:"errors"`
+	Results int           `json:"results"`
+	Paging  struct {
+		Current int `json:"current"`
+		Total   int `json:"total"`
+	} `json:"paging"`
+	Response []TeamData `json:"response"`
+}
+
+type TeamData struct {
+	Team struct {
+		ID       int    `json:"id"`
+		Name     string `json:"name"`
+		Code     string `json:"code"`
+		Country  string `json:"country"`
+		Founded  int    `json:"founded"`
+		National bool   `json:"national"`
+		Logo     string `json:"logo"`
+	} `json:"team"`
+	Venue struct {
+		ID       int    `json:"id"`
+		Name     string `json:"name"`
+		Address  string `json:"address"`
+		City     string `json:"city"`
+		Capacity int    `json:"capacity"`
+		Surface  string `json:"surface"`
+		Image    string `json:"image"`
+	} `json:"venue"`
+}
+
+func (t *TeamData) ToTeam() *models.Team {
+	return &models.Team{
+		Name:        t.Team.Name,
+		SportId:     SoccerSportId,
+		Description: "", // API doesn't provide description
+		ImageURL:    t.Team.Logo,
+		IsActive:    true,
+		ApiID:       t.Team.ID,
+	}
+}
+
+func (tr *TeamsResponse) ToTeams() []models.Team {
+	teams := make([]models.Team, 0, len(tr.Response))
+	for _, teamData := range tr.Response {
+		teams = append(teams, *teamData.ToTeam())
+	}
+	return teams
+}
+
+func InsertTeams(db *bun.DB, teams []models.Team) error {
+	if len(teams) == 0 {
+		return nil
+	}
+
+	_, err := db.NewInsert().
+		Model(&teams).
+		On("CONFLICT (name, sport_id) DO NOTHING").
+		Exec(context.Background())
+	return err
+}

--- a/scripts/soccer/fetch_fixtures.go
+++ b/scripts/soccer/fetch_fixtures.go
@@ -12,16 +12,6 @@ import (
 	"time"
 )
 
-// Cleaned shape aligned with our fixtures schema (without DB IDs yet)
-type CleanFixture struct {
-	SportID  int             `json:"sport_id"`
-	HomeTeam string          `json:"home_team"`
-	AwayTeam string          `json:"away_team"`
-	DateTime time.Time       `json:"date_time"`
-	Status   string          `json:"status"`
-	Details  json.RawMessage `json:"details"`
-}
-
 func fetchFixtures() {
 	cfg := config.GetConfig()
 	db := utils.GetDatabase()
@@ -67,15 +57,6 @@ func fetchFixtures() {
 		log.Fatalf("Error inserting fixtures: %v", err)
 	}
 
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, v := range values {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
 }
 
 func main() {

--- a/scripts/soccer/fetch_fixtures.go
+++ b/scripts/soccer/fetch_fixtures.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"mike/config"
+	"mike/pkg/routes/fixtures/soccer/models"
+	"mike/utils"
+	"net/http"
+	"time"
+)
+
+// Cleaned shape aligned with our fixtures schema (without DB IDs yet)
+type CleanFixture struct {
+	SportID  int             `json:"sport_id"`
+	HomeTeam string          `json:"home_team"`
+	AwayTeam string          `json:"away_team"`
+	DateTime time.Time       `json:"date_time"`
+	Status   string          `json:"status"`
+	Details  json.RawMessage `json:"details"`
+}
+
+func fetchFixtures() {
+	cfg := config.GetConfig()
+	db := utils.GetDatabase()
+
+	leagueID := 39
+	season := "2025"
+
+	url := fmt.Sprintf("%s/fixtures?league=%d&season=%s", cfg.API.FootballAPIURL, leagueID, season)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Fatalf("Error creating request: %v", err)
+	}
+
+	req.Header.Add("X-RapidAPI-Key", cfg.API.FootballAPIKey)
+	req.Header.Add("X-RapidAPI-Host", "v3.football.api-sports.io")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("Error making request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("Error reading response: %v", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		log.Fatalf("API request failed with status: %d, response: %s", resp.StatusCode, string(body))
+	}
+
+	var fixturesResp models.FixturesResponse
+	if err := json.Unmarshal(body, &fixturesResp); err != nil {
+		log.Fatalf("Error parsing JSON: %v", err)
+	}
+
+	fixtures := fixturesResp.ToFixtures()
+
+	err = models.InsertFixtures(db, fixtures)
+	if err != nil {
+		log.Fatalf("Error inserting fixtures: %v", err)
+	}
+
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func main() {
+	fetchFixtures()
+}

--- a/scripts/soccer/fetch_teams.go
+++ b/scripts/soccer/fetch_teams.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"mike/config"
+	"mike/pkg/routes/teams/soccer/models"
+	"mike/utils"
+	"net/http"
+	"time"
+)
+
+func fetchTeams() {
+	cfg := config.GetConfig()
+
+	db := utils.GetDatabase()
+
+	// Premier League ID 39 for 2024 season
+	leagueID := 39
+	season := "2025"
+
+	url := fmt.Sprintf("%s/teams?league=%d&season=%s", cfg.API.FootballAPIURL, leagueID, season)
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Fatalf("Error creating request: %v", err)
+	}
+
+	req.Header.Add("X-RapidAPI-Key", cfg.API.FootballAPIKey)
+	req.Header.Add("X-RapidAPI-Host", "v3.football.api-sports.io")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("Error making request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		log.Fatalf("API request failed with status: %d, response: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("Error reading response: %v", err)
+	}
+
+	// Parse and pretty print JSON
+	var teamsResponse models.TeamsResponse
+	if err := json.Unmarshal(body, &teamsResponse); err != nil {
+		log.Fatalf("Error parsing JSON: %v", err)
+	}
+
+	// Convert to team object
+	teams := teamsResponse.ToTeams()
+
+	// Save to database
+	err = models.InsertTeams(db, teams)
+	if err != nil {
+		log.Fatalf("Error saving teams to database: %v", err)
+	}
+}
+
+func main() {
+	fetchTeams()
+}


### PR DESCRIPTION
- Add script to fetch teams and fixtures for the 2025 PL season.
- Adds an api_id field, which is used to fetch team info for each fixture. 